### PR TITLE
feat: Add book command

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -161,6 +161,7 @@ show_error_codes = true
 warn_unused_configs = true
 warn_return_any = true
 warn_unused_ignores = true
+check_untyped_defs = true
 strict_equality = true
 plugins = ["sqlalchemy.ext.mypy.plugin"]
 

--- a/backend/src/reader/commands/__init__.py
+++ b/backend/src/reader/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Commands for the Reader application."""

--- a/backend/src/reader/commands/__init__.py
+++ b/backend/src/reader/commands/__init__.py
@@ -1,1 +1,5 @@
 """Commands for the Reader application."""
+
+__all__ = ("AddBookCommand",)
+
+from .add_book import AddBookCommand

--- a/backend/src/reader/commands/add_book/README.md
+++ b/backend/src/reader/commands/add_book/README.md
@@ -1,0 +1,126 @@
+# AddBookCommand
+
+`AddBookCommand` imports a book from a local filesystem folder into the Reader
+database. It scans a directory of page images, derives author and book metadata
+from the folder layout, and persists author, book, and page rows in a single
+transaction.
+
+The command implements the [`BaseCommand`](../base.py) interface and follows the
+standard `initialize → validate → execute` lifecycle.
+
+## Folder layout
+
+The command expects a two-level directory layout:
+
+```
+<authors_root>/
+└── <first>_<last>/        # parent folder — encodes the author name
+    └── <book name>/       # book folder — passed as `book_path`
+        ├── 001.jpg
+        ├── 002.jpg
+        └── ...
+```
+
+Rules applied during `validate()`:
+
+- `book_path` must exist and be a directory.
+- `book_path` must contain at least one `.jpg`, `.jpeg`, or `.png` file.
+- The parent folder name is split on `_` to derive the author:
+  - `first_last` → `author_first_name = "first"`, `author_last_name = "last"`.
+  - `first` → `author_first_name = "first"` (no last name).
+  - More than two `_`-separated segments → `ValueError`.
+- `book_name` is derived from the book folder name by replacing `_` and
+  whitespace with single spaces and capitalising the first character
+  (e.g. `the_little_prince` → `The little prince`).
+
+Page records are stored with URLs of the form
+`/static/i/<authors_root>/<author_folder>/<filename>`, sorted lexicographically.
+The first page is also used as the book cover.
+
+## Public attributes
+
+| Attribute           | Type                | Populated by | Description                                  |
+| ------------------- | ------------------- | ------------ | -------------------------------------------- |
+| `book_path`         | `Path`              | `__init__`   | Directory holding the page images.           |
+| `app_config`        | `AppConfig`         | `__init__`   | Database/app configuration.                  |
+| `author_first_name` | `str \| None`       | `validate`   | Parsed from the parent folder name.          |
+| `author_last_name`  | `str \| None`       | `validate`   | Parsed from the parent folder name.          |
+| `book_name`         | `str \| None`       | `validate`   | Derived from `book_path.name`.               |
+| `author_full_name`  | `str` (property)    | computed     | `"first"` or `"first last"`.                 |
+
+## Lifecycle
+
+1. `initialize(**kwargs)` — no-op, kept for `BaseCommand` compatibility.
+2. `validate()` — checks the folder layout and populates `book_name`,
+   `author_first_name`, and `author_last_name`. Raises `ValueError` on any
+   layout violation.
+3. `execute()` — opens a database session and creates one `Author`, one `Book`,
+   and one `Page` per image. Logs a JSON summary of what was inserted.
+
+`str(command)` returns a JSON snapshot of the current command state, which is
+useful for dry-run previews before calling `execute()`.
+
+## Usage examples
+
+### Programmatic use
+
+```python
+from pathlib import Path
+
+from reader.commands.add_book import AddBookCommand
+from reader.config import AppConfig
+
+command = AddBookCommand(
+    book_path=Path("/data/books/antoine_de-saint-exupery/the_little_prince"),
+    app_config=AppConfig.get_or_create(),
+)
+
+await command.initialize()
+await command.validate()
+await command.execute()
+```
+
+### Dry-run preview
+
+`__str__` returns the parsed metadata without touching the database:
+
+```python
+command = AddBookCommand("/data/books/lewis_carroll/alice_in_wonderland")
+await command.initialize()
+await command.validate()
+print(command)
+```
+
+Example output:
+
+```json
+{
+  "Book path": "/data/books/lewis_carroll/alice_in_wonderland",
+  "Author first name": "lewis",
+  "Author last name": "carroll",
+  "Author full name": "lewis carroll",
+  "Book name": "Alice in wonderland"
+}
+```
+
+### CLI
+
+The command is wired into the Reader CLI as `add-book`
+(see [`utils/cli/main.py`](../../utils/cli/main.py)):
+
+```bash
+# Import the book into the database
+reader add-book --book-path /data/books/lewis_carroll/alice_in_wonderland
+
+# Print the parsed structure without persisting anything
+reader add-book --book-path /data/books/lewis_carroll/alice_in_wonderland --preview
+```
+
+## Errors
+
+`validate()` raises `ValueError` when:
+
+- `book_path` does not exist or is not a directory.
+- The parent of `book_path` is not a directory.
+- `book_path` contains no `.jpg`/`.jpeg`/`.png` files.
+- The parent folder name has more than two `_`-separated segments.

--- a/backend/src/reader/commands/add_book/__init__.py
+++ b/backend/src/reader/commands/add_book/__init__.py
@@ -1,0 +1,5 @@
+"""Commands for the Reader application."""
+
+__all__ = ("AddBookCommand",)
+
+from .add_book_command import AddBookCommand

--- a/backend/src/reader/commands/add_book/add_book_command.py
+++ b/backend/src/reader/commands/add_book/add_book_command.py
@@ -25,7 +25,7 @@ class AddBookCommand(BaseCommand):
     author_first_name: str | None = None
     author_last_name: str | None = None
     book_name: str | None = None
-    files_extensions: tuple[str, ...] = (".jpg", ".jpeg", ".png")
+    file_extensions: tuple[str, ...] = (".jpg", ".jpeg", ".png")
 
     def __init__(self, book_path: Path | str, app_config: AppConfig | None = None):
         """Create an import command for the given book folder.
@@ -125,7 +125,7 @@ class AddBookCommand(BaseCommand):
         if not (parent_folder := self.book_path.parent).is_dir():
             raise ValueError(f"Parent folder {parent_folder} is not a directory")
         for item in self.book_path.iterdir():
-            if item.is_file() and item.suffix in self.files_extensions:
+            if item.is_file() and item.suffix in self.file_extensions:
                 break
         else:
             raise ValueError(f"Book path {self.book_path} does not contain any image files")
@@ -156,7 +156,7 @@ class AddBookCommand(BaseCommand):
         pages: list[str] = []
 
         for item in self.book_path.iterdir():
-            if item.is_file() and item.suffix in self.files_extensions:
+            if item.is_file() and item.suffix in self.file_extensions:
                 pages.append(f"/static/i/{item.parent.parent.name}/{item.parent.name}/{item.name}")
 
         pages.sort()

--- a/backend/src/reader/commands/add_book/add_book_command.py
+++ b/backend/src/reader/commands/add_book/add_book_command.py
@@ -1,5 +1,7 @@
 """CLI command that imports a book from a filesystem folder into the database."""
 
+__all__ = ("AddBookCommand",)
+
 import json
 import re
 from pathlib import Path

--- a/backend/src/reader/commands/add_book/add_book_command.py
+++ b/backend/src/reader/commands/add_book/add_book_command.py
@@ -1,0 +1,174 @@
+"""CLI command that imports a book from a filesystem folder into the database."""
+
+import json
+import re
+from pathlib import Path
+
+from loguru import logger
+
+from reader.config import AppConfig
+from reader.services.daos import AuthorDAO, BookDAO, PageDAO
+from reader.services.database import AsyncDatabaseClient
+
+from ..base import BaseCommand
+
+
+class AddBookCommand(BaseCommand):
+    """Load book images under ``book_path`` and persist author, book, and pages.
+
+    The parent directory name optionally encodes ``author_first_name``
+    ``author_last_name`` as ``first_last`` segments separated by underscores.
+    """
+
+    author_first_name: str | None = None
+    author_last_name: str | None = None
+    book_name: str | None = None
+    files_extensions: tuple[str, ...] = (".jpg", ".jpeg", ".png")
+
+    def __init__(self, book_path: Path | str, app_config: AppConfig | None = None):
+        """Create an import command for the given book folder.
+
+        Args:
+            book_path (Path | str): Directory containing page images (.jpg/.jpeg/.png).
+            app_config (AppConfig, optional): Database and app configuration.
+                Defaults to ``AppConfig.get_or_create()`` when omitted.
+
+        Returns:
+            None
+
+        """
+        self.book_path = Path(book_path)
+        self.app_config = app_config or AppConfig.get_or_create()
+
+    def _book_structure(
+        self, book_cover: str | None = None, pages: list[str] | None = None
+    ) -> dict[str, Path | str | list[str]]:
+        """Build a JSON-serializable summary of detected book metadata.
+
+        Args:
+            book_cover (str, optional): Representative cover URL or path fragment.
+                Defaults to None (omitted from the payload).
+            pages (list[str], optional): Sorted page identifiers. Defaults to None
+                (omitted from the payload).
+
+        Returns:
+            dict[str, Path | str | list[str]]: Keys such as ``Book path``, names, and optional ``Book cover``
+            / ``Pages``. Values may include non-string objects coerced via ``json.dumps``.
+
+        """
+        payload = {
+            "Book path": self.book_path,
+            "Author first name": self.author_first_name,
+            "Author last name": self.author_last_name,
+            "Author full name": self.author_full_name,
+            "Book name": self.book_name,
+        }
+        if book_cover is not None:
+            payload["Book cover"] = book_cover
+        if pages is not None:
+            payload["Pages"] = pages  # type: ignore[assignment]
+
+        return payload  # type: ignore[return-value]
+
+    def __str__(self) -> str:
+        """Return indented JSON describing the command state.
+
+        Returns:
+            str: JSON text for the default book-structure payload without cover/pages.
+
+        """
+        return json.dumps(self._book_structure(), indent=2, default=str)
+
+    @property
+    def author_full_name(self) -> str:
+        """Compose a display name from first and optional last author name.
+
+        Returns:
+            str: ``first_only`` when last name is absent, otherwise ``first last``.
+
+        """
+        if self.author_last_name is None:
+            return self.author_first_name  # type: ignore[return-value]
+
+        return f"{self.author_first_name} {self.author_last_name}"
+
+    async def initialize(self, **kwargs):
+        """Initialize the command.
+
+        Args:
+            **kwargs: Unused keyword arguments retained for ``BaseCommand`` compatibility.
+
+        Returns:
+            None
+
+        """
+        pass
+
+    async def validate(self):
+        """Ensure ``book_path`` layout and derive ``book_name`` and author fields.
+
+        Returns:
+            None
+
+        Raises:
+            ValueError: If ``book_path`` or its parent is missing or not a directory,
+                if no image pages exist inside ``book_path``, or if the parent folder
+                name has more than two underscore-separated segments.
+
+        """
+        if not self.book_path.exists():
+            raise ValueError(f"Book path {self.book_path} does not exist")
+        if not self.book_path.is_dir():
+            raise ValueError(f"Book path {self.book_path} is not a directory")
+        if not (parent_folder := self.book_path.parent).is_dir():
+            raise ValueError(f"Parent folder {parent_folder} is not a directory")
+        for item in self.book_path.iterdir():
+            if item.is_file() and item.suffix in self.files_extensions:
+                break
+        else:
+            raise ValueError(f"Book path {self.book_path} does not contain any image files")
+
+        self.book_name = re.sub(r"_|\s+", " ", self.book_path.name.capitalize())
+
+        if len(parent_splited := parent_folder.name.split("_")) > 2:
+            raise ValueError(f"Parent folder {parent_folder} has more than 2 parts")
+
+        if len(parent_splited) == 2:
+            self.author_first_name = parent_splited[0]
+            self.author_last_name = parent_splited[1]
+        elif len(parent_splited) == 1:
+            self.author_first_name = parent_splited[0]
+
+    async def execute(self):
+        """Create author, book, and page rows and print a JSON summary to stdout.
+
+        Page paths are stored as ``/static/i/{grandparent}/{parent}/{filename}`` relative-style
+        strings derived from the image files in ``book_path``.
+
+        Returns:
+            None
+
+        """
+        logger.info(f"Adding book {self.book_path}...")
+        db_client = AsyncDatabaseClient(self.app_config)
+        pages: list[str] = []
+
+        for item in self.book_path.iterdir():
+            if item.is_file() and item.suffix in self.files_extensions:
+                pages.append(f"/static/i/{item.parent.parent.name}/{item.parent.name}/{item.name}")
+
+        pages.sort()
+
+        async with db_client.session_factory() as session:
+            book_dao = BookDAO(database_client=None, session=session)
+            author_dao = AuthorDAO(database_client=None, session=session)
+            page_dao = PageDAO(database_client=None, session=session)
+
+            author = await author_dao.create(
+                first_name=self.author_first_name, last_name=self.author_last_name, cover=None
+            )
+            book = await book_dao.create(name=self.book_name, author_id=author.id, cover=pages[0])
+            for index, page in enumerate(pages, start=1):
+                await page_dao.create(book_id=book.id, position=index, cover=page)
+
+        logger.info(json.dumps(self._book_structure(book_cover=pages[0], pages=pages), indent=2, default=str))

--- a/backend/src/reader/commands/base.py
+++ b/backend/src/reader/commands/base.py
@@ -7,31 +7,12 @@ from typing import Any
 
 
 class BaseCommand(ABC):
-    """Abstract base class for command pattern implementation.
+    """Abstract async command with initialize, validate, and execute hooks.
 
-    This class defines the interface for all command objects in the application.
-    Commands encapsulate business logic operations that can be validated before
-    execution, providing a consistent way to handle operations with pre-conditions.
-
-    All concrete command classes must implement both the validate and execute methods.
-    The typical usage pattern is:
-    1. Validate the command's preconditions
-    2. Execute the command's business logic
-
-    Example:
-        >>> class CreateUserCommand(BaseCommand):
-        ...     def __init__(self, username: str, email: str):
-        ...         self.username = username
-        ...         self.email = email
-        ...
-        ...     def validate(self) -> None:
-        ...         if not self.email or '@' not in self.email:
-        ...             raise ValueError("Invalid email")
-        ...
-        ...     def execute(self) -> None:
-        ...         # Create user logic here
-        ...         pass
-
+    Subclasses implement the three-step lifecycle: optional setup via
+    ``initialize``, precondition checks in ``validate``, then ``execute`` for
+    the main work. Call ``validate`` before ``execute`` once prerequisites
+    are ready.
     """
 
     @abstractmethod

--- a/backend/src/reader/commands/base.py
+++ b/backend/src/reader/commands/base.py
@@ -1,0 +1,74 @@
+"""Base command interface for implementing the Command pattern."""
+
+__all__ = ("BaseCommand",)
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class BaseCommand(ABC):
+    """Abstract base class for command pattern implementation.
+
+    This class defines the interface for all command objects in the application.
+    Commands encapsulate business logic operations that can be validated before
+    execution, providing a consistent way to handle operations with pre-conditions.
+
+    All concrete command classes must implement both the validate and execute methods.
+    The typical usage pattern is:
+    1. Validate the command's preconditions
+    2. Execute the command's business logic
+
+    Example:
+        >>> class CreateUserCommand(BaseCommand):
+        ...     def __init__(self, username: str, email: str):
+        ...         self.username = username
+        ...         self.email = email
+        ...
+        ...     def validate(self) -> None:
+        ...         if not self.email or '@' not in self.email:
+        ...             raise ValueError("Invalid email")
+        ...
+        ...     def execute(self) -> None:
+        ...         # Create user logic here
+        ...         pass
+
+    """
+
+    @abstractmethod
+    async def initialize(self, **_: Any) -> None:
+        """Initialize the command with the given arguments.
+
+        Args:
+            **_: Additional keyword arguments for the command.
+
+        """
+        pass
+
+    @abstractmethod
+    async def execute(self) -> None:
+        """Execute the command's business logic.
+
+        This method contains the main operation that the command performs.
+        It should only be called after validate() has been called and passed
+        successfully.
+
+        Raises:
+            Implementation-specific exceptions based on the command's logic
+
+        """
+        pass
+
+    @abstractmethod
+    async def validate(self) -> None:
+        """Validate the command's preconditions before execution.
+
+        This method checks that all required data is present and valid before
+        the command is executed. It should raise appropriate exceptions if
+        validation fails.
+
+        Raises:
+            ValueError: If any validation constraint is not met
+            Implementation-specific exceptions based on validation logic
+
+        """
+        pass

--- a/backend/src/reader/services/alembic/migrations/versions/2025_01_18_1324-8e3f5d72efaf_init.py
+++ b/backend/src/reader/services/alembic/migrations/versions/2025_01_18_1324-8e3f5d72efaf_init.py
@@ -96,9 +96,8 @@ def downgrade() -> None:
         None.
 
     """
-    op.drop_table("category")
-    op.drop_table("author")
-    op.drop_table("book")
-    op.drop_table("page")
-
     op.drop_table("category_book_table")
+    op.drop_table("category")
+    op.drop_table("page")
+    op.drop_table("book")
+    op.drop_table("author")

--- a/backend/src/reader/utils/cli/main.py
+++ b/backend/src/reader/utils/cli/main.py
@@ -6,6 +6,7 @@ import asyncclick as click
 import uvicorn
 
 from reader import __version__ as app_version
+from reader.commands.add_book import AddBookCommand
 from reader.config import AppConfig
 
 
@@ -66,3 +67,34 @@ def run(host: str, port: int, reload: bool) -> None:
         reload=reload,
         factory=True,
     )
+
+
+@main.command(help="Add a book to the Reader application.")
+@click.option("--book-path", type=click.Path(exists=True, file_okay=False, dir_okay=True), required=True)
+@click.option("--preview", is_flag=True, help="Preview the book structure.", default=False)
+@click.pass_context
+async def add_book(ctx: click.Context, book_path: str, preview: bool) -> None:
+    """Add a book from a local directory or print a dry-run preview.
+
+    Initializes and validates the add-book workflow against ``book_path``. When
+    ``preview`` is set, prints the command state without persisting changes.
+
+    Args:
+        ctx (click.Context): Command context populated by ``main``.
+        book_path (str): Path to the book directory on disk.
+        preview (bool, optional): If true, print the command only. Defaults to
+            ``False``.
+
+    Returns:
+        None
+
+    """
+    app_config: AppConfig = ctx.obj["config"]
+    command = AddBookCommand(book_path, app_config=app_config)
+    await command.initialize()
+    await command.validate()
+
+    if preview:
+        click.echo(str(command))
+    else:
+        await command.execute()


### PR DESCRIPTION
This pull request introduces a new command pattern framework for the Reader application, focused on adding support for importing books from a local directory via both programmatic and CLI interfaces. It includes a robust implementation of the `AddBookCommand`, a shared `BaseCommand` interface, and integration with the CLI. The changes also improve type-checking strictness and fix the Alembic migration downgrade order.

**New Command Pattern and Book Import Functionality:**

* Introduced a reusable `BaseCommand` abstract class in `base.py` to standardize command lifecycle (`initialize`, `validate`, `execute`) across the codebase.
* Added the `AddBookCommand` in `add_book_command.py` with full documentation and a `README.md`, implementing book import from a filesystem directory, including author and book metadata extraction, validation, and database persistence. [[1]](diffhunk://#diff-4e0f7edf256e3f3cfc8a3589e9af4c5c4c75296846952d68c4ed5afd2429b7c2R1-R174) [[2]](diffhunk://#diff-c07b8a192ee78ea916b20a4e6751a187a260407ce3bce5ac5f787196a0ce6579R1-R126)
* Registered `AddBookCommand` in the package `__init__.py` files for import and discovery. [[1]](diffhunk://#diff-1fe765f15b61ead055b8aeb41e7efaf6f4150208cafa2c306c9658f21c275975R1) [[2]](diffhunk://#diff-d77d2b0d322d79b5722c107303084a0ced0caef35d93061c2c8035b32b892137R1-R5)

**CLI Integration:**

* Added a new `add-book` command to the CLI (`main.py`) that supports both importing a book and previewing the parsed structure without database writes, using the new command framework. [[1]](diffhunk://#diff-003437e473f0be550acf129e4b8b5649da46bddca4291c7f58395ad28e51e13bR9) [[2]](diffhunk://#diff-003437e473f0be550acf129e4b8b5649da46bddca4291c7f58395ad28e51e13bR70-R100)

**Other Improvements:**

* Enabled `check_untyped_defs` in `pyproject.toml` for stricter mypy type checking.
* Fixed the order of table drops in the Alembic migration downgrade for proper dependency handling.