### PR TITLE
feat: Add slug

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "pydantic-settings[yaml]>=2.14.1",
     "pydash>=8.0",
     "pyjwt>=2.12.1",
+    "python-slugify[unidecode]>=8.0.4",
     "sqlalchemy[asyncio]>=2.0.44",
     "uvicorn>=0.47.0",
 ]

--- a/backend/src/reader/__init__.py
+++ b/backend/src/reader/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ("__version__",)
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"

--- a/backend/src/reader/modules/routers/models/requests/authors/patch_author_body.py
+++ b/backend/src/reader/modules/routers/models/requests/authors/patch_author_body.py
@@ -10,6 +10,6 @@ from reader.modules.routers.models.base import BaseRequestModel
 class PatchAuthorBody(BaseRequestModel):
     """Body model for patching an author."""
 
-    first_name: str | None = Field(None, description="The first name of the author")
-    last_name: str | None = Field(None, description="The last name of the author")
+    first_name: str | None = Field(None, description="The first name of the author", min_length=1, max_length=255)
+    last_name: str | None = Field(None, description="The last name of the author", min_length=1, max_length=255)
     cover: str | None = Field(None, description="The cover of the author")

--- a/backend/src/reader/modules/routers/models/requests/authors/post_author_body.py
+++ b/backend/src/reader/modules/routers/models/requests/authors/post_author_body.py
@@ -10,6 +10,6 @@ from reader.modules.routers.models.base import BaseRequestModel
 class PostAuthorBody(BaseRequestModel):
     """Body model for creating an author."""
 
-    first_name: str = Field(..., description="The first name of the author")
-    last_name: str | None = Field(None, description="The last name of the author")
+    first_name: str = Field(..., description="The first name of the author", min_length=1, max_length=255)
+    last_name: str | None = Field(None, description="The last name of the author", min_length=1, max_length=255)
     cover: str | None = Field(None, description="The cover of the author")

--- a/backend/src/reader/modules/routers/models/requests/books/get_all_books_query.py
+++ b/backend/src/reader/modules/routers/models/requests/books/get_all_books_query.py
@@ -9,8 +9,8 @@ from reader.modules.routers.models.base.metadata import PaginationWithFiltersQue
 
 class GetAllBooksQuery(
     PaginationWithFiltersQuery[
-        Literal["id", "name", "author_id", "created_at", "updated_at", "watches_count"],
-        Literal["id", "name", "author_id", "created_at", "updated_at", "watches_count"],
+        Literal["id", "name", "author_id", "created_at", "updated_at", "watches_count", "slug"],
+        Literal["id", "name", "author_id", "created_at", "updated_at", "watches_count", "slug"],
     ]
 ):
     """Query model for getting all books."""

--- a/backend/src/reader/modules/routers/models/requests/books/get_all_books_query.py
+++ b/backend/src/reader/modules/routers/models/requests/books/get_all_books_query.py
@@ -9,8 +9,8 @@ from reader.modules.routers.models.base.metadata import PaginationWithFiltersQue
 
 class GetAllBooksQuery(
     PaginationWithFiltersQuery[
-        Literal["id", "name", "author_id", "created_at", "updated_at"],
-        Literal["id", "name", "author_id", "created_at", "updated_at"],
+        Literal["id", "name", "author_id", "created_at", "updated_at", "watches_count"],
+        Literal["id", "name", "author_id", "created_at", "updated_at", "watches_count"],
     ]
 ):
     """Query model for getting all books."""

--- a/backend/src/reader/modules/routers/models/requests/books/patch_book_body.py
+++ b/backend/src/reader/modules/routers/models/requests/books/patch_book_body.py
@@ -10,7 +10,7 @@ from reader.modules.routers.models.base import BaseRequestModel
 class PatchBookBody(BaseRequestModel):
     """Body model for patching a book."""
 
-    name: str | None = Field(None, description="The name of the book")
-    description: str | None = Field(None, description="The description of the book")
+    name: str | None = Field(None, description="The name of the book", min_length=1, max_length=255)
+    description: str | None = Field(None, description="The description of the book", min_length=1, max_length=1000)
     cover: str | None = Field(None, description="The cover of the book")
     author_id: int | None = Field(None, description="The ID of the author of the book")

--- a/backend/src/reader/modules/routers/models/requests/books/post_book_body.py
+++ b/backend/src/reader/modules/routers/models/requests/books/post_book_body.py
@@ -10,7 +10,7 @@ from reader.modules.routers.models.base import BaseRequestModel
 class PostBookBody(BaseRequestModel):
     """Body model for creating a book."""
 
-    name: str = Field(..., description="The name of the book")
-    description: str | None = Field(None, description="The description of the book")
+    name: str = Field(..., description="The name of the book", min_length=1, max_length=255)
+    description: str | None = Field(None, description="The description of the book", min_length=1, max_length=1000)
     cover: str | None = Field(None, description="The cover of the book")
     author_id: int = Field(..., description="The ID of the author of the book")

--- a/backend/src/reader/modules/routers/models/requests/categories/patch_category_body.py
+++ b/backend/src/reader/modules/routers/models/requests/categories/patch_category_body.py
@@ -10,6 +10,6 @@ from reader.modules.routers.models.base import BaseRequestModel
 class PatchCategoryBody(BaseRequestModel):
     """Body model for patching a category."""
 
-    name: str | None = Field(None, description="The name of the category")
-    description: str | None = Field(None, description="The description of the category")
+    name: str | None = Field(None, description="The name of the category", min_length=1, max_length=255)
+    description: str | None = Field(None, description="The description of the category", min_length=1, max_length=1000)
     cover: str | None = Field(None, description="The cover of the category")

--- a/backend/src/reader/modules/routers/models/requests/categories/post_category_body.py
+++ b/backend/src/reader/modules/routers/models/requests/categories/post_category_body.py
@@ -10,6 +10,6 @@ from reader.modules.routers.models.base import BaseRequestModel
 class PostCategoryBody(BaseRequestModel):
     """Body model for creating a category."""
 
-    name: str = Field(..., description="The name of the category")
-    description: str | None = Field(None, description="The description of the category")
+    name: str = Field(..., description="The name of the category", min_length=1, max_length=255)
+    description: str | None = Field(None, description="The description of the category", min_length=1, max_length=1000)
     cover: str | None = Field(None, description="The cover of the category")

--- a/backend/src/reader/modules/routers/models/requests/pages/patch_page_body.py
+++ b/backend/src/reader/modules/routers/models/requests/pages/patch_page_body.py
@@ -10,6 +10,6 @@ from reader.modules.routers.models.base import BaseRequestModel
 class PatchPageBody(BaseRequestModel):
     """Body model for patching a page."""
 
-    position: int | None = Field(None, description="The position of the page within the book")
+    position: int | None = Field(None, description="The position of the page within the book", ge=1)
     cover: str | None = Field(None, description="The cover of the page")
     book_id: int | None = Field(None, description="The ID of the book the page belongs to")

--- a/backend/src/reader/modules/routers/models/requests/pages/post_page_body.py
+++ b/backend/src/reader/modules/routers/models/requests/pages/post_page_body.py
@@ -10,6 +10,6 @@ from reader.modules.routers.models.base import BaseRequestModel
 class PostPageBody(BaseRequestModel):
     """Body model for creating a page."""
 
-    position: int = Field(..., description="The position of the page within the book")
+    position: int = Field(..., description="The position of the page within the book", ge=1)
     cover: str | None = Field(None, description="The cover of the page")
     book_id: int = Field(..., description="The ID of the book the page belongs to")

--- a/backend/src/reader/modules/routers/models/responses/books/get_single_book_response.py
+++ b/backend/src/reader/modules/routers/models/responses/books/get_single_book_response.py
@@ -18,4 +18,5 @@ class GetSingleBookResponse(BaseResponseFromModelSchema, BaseDateModel):
     cover: str | None = Field(None, description="The cover of the book")
     author_id: int = Field(..., description="The ID of the author of the book")
     watches_count: int = Field(..., description="The number of times the book has been watched")
+    slug: str = Field(..., description="The slug of the book")
     author: SimpleAuthorResponse = Field(..., description="The author of the book")

--- a/backend/src/reader/modules/routers/models/responses/books/simple_book_response.py
+++ b/backend/src/reader/modules/routers/models/responses/books/simple_book_response.py
@@ -16,3 +16,4 @@ class SimpleBookResponse(BaseResponseFromModelSchema, BaseDateModel):
     description: str | None = Field(None, description="The description of the book")
     cover: str | None = Field(None, description="The cover of the book")
     watches_count: int = Field(..., description="The number of times the book has been watched")
+    slug: str = Field(..., description="The slug of the book")

--- a/backend/src/reader/services/alembic/migrations/versions/2025_01_18_1324-8e3f5d72efaf_init.py
+++ b/backend/src/reader/services/alembic/migrations/versions/2025_01_18_1324-8e3f5d72efaf_init.py
@@ -41,15 +41,17 @@ def upgrade() -> None:
         Column("last_name", String),
         Column("cover", String, nullable=True),
         PrimaryKeyConstraint("id", name="pk_author"),
+        UniqueConstraint("first_name", "last_name", name="uq_author_name"),
     )
     op.create_table(
         "book",
         Column("id", Integer),
-        Column("name", String, unique=True, nullable=False),
+        Column("name", String, nullable=False),
         Column("description", String),
         Column("author_id", Integer(), nullable=False),
         Column("cover", String, nullable=True),
         PrimaryKeyConstraint("id", name="pk_book"),
+        UniqueConstraint("name", name="uq_book_name"),
         ForeignKeyConstraint(
             ["author_id"],
             ["author.id"],

--- a/backend/src/reader/services/alembic/migrations/versions/2026-05-19_12-26_92552180df13_add_slug_field.py
+++ b/backend/src/reader/services/alembic/migrations/versions/2026-05-19_12-26_92552180df13_add_slug_field.py
@@ -1,0 +1,93 @@
+"""Add a unique ``slug`` column to ``book`` and backfill from names.
+
+Adds ``slug``, fills values from slugified titles with numeric suffixes on
+collisions, enforces uniqueness and not-null, and briefly drops/recreates
+foreign keys so SQLite batch alterations can apply.
+
+Revision ID: 92552180df13
+Revises: b922d12d33b3
+Create Date: 2026-05-19 12:26:48.585370
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from slugify import slugify
+from sqlalchemy.sql import column, select, table, update
+
+# revision identifiers, used by Alembic.
+revision: str = "92552180df13"
+down_revision: Union[str, None] = "b922d12d33b3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+book = table("book", column("id"), column("name"), column("slug"))
+
+
+def upgrade() -> None:
+    """Add ``slug`` to ``book``, backfill, then constrain and index it.
+
+    Temporarily drops ``page.fk_book_id`` and ``book.fk_author_id`` so the
+    ``book`` table can be altered under SQLite batch mode, then restores them.
+
+    Returns:
+        None
+
+    """
+    op.add_column("book", sa.Column("slug", sa.String(), nullable=True))
+
+    conn = op.get_bind()
+    rows = conn.execute(select(book.c.id, book.c.name)).fetchall()
+    seen_slugs: dict[str, int] = {}
+    for book_id, name in rows:
+        base = slugify(name or "") or f"book-{book_id}"
+        slug_value = base
+        suffix = 1
+        while slug_value in seen_slugs:
+            slug_value = f"{base}-{suffix}"
+            suffix += 1
+        seen_slugs[slug_value] = book_id
+        conn.execute(update(book).values(slug=slug_value).where(book.c.id == book_id))
+
+    with op.batch_alter_table("page") as batch_op:
+        batch_op.drop_constraint("fk_book_id", type_="foreignkey")
+
+    with op.batch_alter_table("book") as batch_op:
+        batch_op.drop_constraint("fk_author_id", type_="foreignkey")
+
+    with op.batch_alter_table("book") as batch_op:
+        batch_op.create_unique_constraint("uq_book_slug", ["slug"])
+        batch_op.create_index("idx_book_slug", ["slug"])
+        batch_op.alter_column("slug", nullable=False)
+        batch_op.create_foreign_key("fk_author_id", "author", ["author_id"], ["id"])
+
+    with op.batch_alter_table("page") as batch_op:
+        batch_op.create_foreign_key("fk_book_id", "book", ["book_id"], ["id"])
+
+
+def downgrade() -> None:
+    """Remove ``slug`` from ``book`` and restore prior FK wiring.
+
+    Mirrors ``upgrade`` by dropping FKs before batch changes, then
+    re-creating them.
+
+    Returns:
+        None
+
+    """
+    with op.batch_alter_table("page") as batch_op:
+        batch_op.drop_constraint("fk_book_id", type_="foreignkey")
+
+    with op.batch_alter_table("book") as batch_op:
+        batch_op.drop_constraint("fk_author_id", type_="foreignkey")
+
+    with op.batch_alter_table("book") as batch_op:
+        batch_op.drop_constraint("uq_book_slug", type_="unique")
+        batch_op.drop_index("idx_book_slug")
+        batch_op.drop_column("slug")
+        batch_op.create_foreign_key("fk_author_id", "author", ["author_id"], ["id"])
+
+    with op.batch_alter_table("page") as batch_op:
+        batch_op.create_foreign_key("fk_book_id", "book", ["book_id"], ["id"])

--- a/backend/src/reader/services/daos/book_dao.py
+++ b/backend/src/reader/services/daos/book_dao.py
@@ -26,6 +26,7 @@ class BookDAO(BaseDAO[Book]):
         Book.created_at,
         Book.updated_at,
         Book.watches_count,
+        Book.slug,
     )
     select_in_options_single = (Book.author, Book.categories, Book.pages)
     select_in_options_all = (Book.author,)

--- a/backend/src/reader/services/database/models/book.py
+++ b/backend/src/reader/services/database/models/book.py
@@ -4,6 +4,7 @@ __all__ = ("Book",)
 
 from typing import TYPE_CHECKING
 
+from slugify import slugify
 from sqlalchemy import ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -33,6 +34,24 @@ class Book(Base, DateTimeMixin):
         "Category", secondary="category_book_table", back_populates="books"
     )
     pages: Mapped[list["Page"]] = relationship("Page", back_populates="book")
+    slug: Mapped[str] = mapped_column(String, nullable=False, unique=True, index=True)
+
+    def __init__(self, *args, **kwargs):
+        """Build a ``Book``, defaulting ``slug`` from ``name`` when omitted.
+
+        Args:
+            *args: Positional arguments forwarded to ``Base.__init__``.
+            **kwargs: Column values for the entity. Include ``name`` when
+                ``slug`` is omitted so a slug can be derived.
+
+        Returns:
+            None:
+
+        """
+        if "slug" not in kwargs:
+            kwargs["slug"] = slugify(kwargs["name"])
+
+        super().__init__(*args, **kwargs)
 
     @property
     def author_name(self) -> str:

--- a/backend/tests/api/test_books_api.py
+++ b/backend/tests/api/test_books_api.py
@@ -259,9 +259,7 @@ class TestBooksApi:
 
         """
         author_id = await _create_author(admin_client)
-        created = (
-            await admin_client.post("/api/v1/book", json={"name": "Rewatched", "author_id": author_id})
-        ).json()
+        created = (await admin_client.post("/api/v1/book", json={"name": "Rewatched", "author_id": author_id})).json()
         initial_watches = created["watchesCount"]
 
         for _ in range(3):

--- a/backend/tests/migrations/test_add_create_at_update_at_columns_revision.py
+++ b/backend/tests/migrations/test_add_create_at_update_at_columns_revision.py
@@ -117,9 +117,7 @@ class TestUpgradeToAddCreatedUpdatedColumnsRevision:
         info = _columns(sqlite_db_path, table)
         for column in NEW_COLUMNS:
             row = info[column]
-            assert row[2].upper() == "DATETIME", (
-                f"{table}.{column} type expected DATETIME, got {row[2]}"
-            )
+            assert row[2].upper() == "DATETIME", f"{table}.{column} type expected DATETIME, got {row[2]}"
             assert bool(row[3]) is True, f"{table}.{column} should be NOT NULL"
 
     def test_preserves_pre_existing_tables(

--- a/backend/tests/migrations/test_add_slug_field_revision.py
+++ b/backend/tests/migrations/test_add_slug_field_revision.py
@@ -1,0 +1,588 @@
+"""Tests for Alembic revision ``92552180df13`` — add ``book.slug``.
+
+Exercises the fifth migration in isolation: upgrading from the prior revision
+(``b922d12d33b3``) should add a NOT NULL ``slug`` column to ``book``, backfill
+it from slugified names (with numeric suffixes for collisions and a
+``book-<id>`` fallback for empty slugs), declare a unique constraint plus
+index on ``slug``, and leave the dropped-and-recreated foreign keys
+(``book.fk_author_id``, ``page.fk_book_id``) in place. Downgrading should
+remove only ``slug`` and restore the same FKs.
+"""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+
+from .conftest import alembic_version, table_names
+
+REVISION = "92552180df13"
+PREVIOUS_REVISION = "b922d12d33b3"
+
+NEW_COLUMN = "slug"
+NEW_INDEX = "idx_book_slug"
+NEW_UNIQUE_CONSTRAINT_TARGETS: frozenset[str] = frozenset({"slug"})
+PRE_EXISTING_TABLES: frozenset[str] = frozenset(
+    {"author", "book", "category", "category_book_table", "page", "user"},
+)
+PRE_EXISTING_BOOK_COLUMNS: frozenset[str] = frozenset(
+    {
+        "id",
+        "name",
+        "description",
+        "cover",
+        "author_id",
+        "created_at",
+        "updated_at",
+        "watches_count",
+    },
+)
+
+
+def _book_table_info(db_path: Path) -> list[tuple]:
+    """Return raw ``PRAGMA table_info('book')`` rows.
+
+    Args:
+        db_path (pathlib.Path): SQLite file to inspect.
+
+    Returns:
+        list[tuple]: One row per column ``(cid, name, type, notnull, dflt, pk)``.
+
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return conn.execute("PRAGMA table_info('book')").fetchall()
+    finally:
+        conn.close()
+
+
+def _unique_columns(db_path: Path, table: str) -> set[str]:
+    """Return single-column ``UNIQUE`` constraints declared on ``table``.
+
+    Args:
+        db_path (pathlib.Path): SQLite file to inspect.
+        table (str): Target table name.
+
+    Returns:
+        set[str]: Column names that participate in a unique index alone.
+
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        indexes = conn.execute(f"PRAGMA index_list('{table}')").fetchall()
+        uniques: set[str] = set()
+        for index in indexes:
+            _seq, name, unique, _origin, _partial = index
+            if not unique:
+                continue
+            cols = conn.execute(f"PRAGMA index_info('{name}')").fetchall()
+            if len(cols) == 1:
+                uniques.add(cols[0][2])
+        return uniques
+    finally:
+        conn.close()
+
+
+def _index_names(db_path: Path, table: str) -> set[str]:
+    """Return all index names declared on ``table``.
+
+    Args:
+        db_path (pathlib.Path): SQLite file to inspect.
+        table (str): Target table name.
+
+    Returns:
+        set[str]: Index names from ``PRAGMA index_list``.
+
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return {row[1] for row in conn.execute(f"PRAGMA index_list('{table}')").fetchall()}
+    finally:
+        conn.close()
+
+
+def _foreign_key_targets(db_path: Path, table: str) -> set[tuple[str, str, str]]:
+    """Return ``(referenced_table, from_column, to_column)`` triples for ``table``.
+
+    Args:
+        db_path (pathlib.Path): SQLite file to inspect.
+        table (str): Table whose foreign keys to enumerate.
+
+    Returns:
+        set[tuple[str, str, str]]: One triple per declared FK.
+
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute(f"PRAGMA foreign_key_list('{table}')").fetchall()
+    finally:
+        conn.close()
+    return {(row[2], row[3], row[4]) for row in rows}
+
+
+def _seed_books(db_path: Path, names: list[str]) -> list[int]:
+    """Insert one author and a book per ``names`` at the previous-revision schema.
+
+    The previous revision predates the ``slug`` column, so books can be
+    written by name alone. ``author_id`` is required (NOT NULL) and points at
+    a single freshly-inserted author shared by every seeded book.
+
+    Args:
+        db_path (pathlib.Path): SQLite file already upgraded to
+            ``PREVIOUS_REVISION``.
+        names (list[str]): Book ``name`` values to insert in order.
+
+    Returns:
+        list[int]: Assigned ``book.id`` values in the same order as ``names``.
+
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        cur = conn.execute(
+            "INSERT INTO author (first_name, last_name) VALUES (?, ?)",
+            ("Test", "Author"),
+        )
+        author_id = cur.lastrowid
+        book_ids: list[int] = []
+        for name in names:
+            cur = conn.execute(
+                "INSERT INTO book (name, author_id) VALUES (?, ?)",
+                (name, author_id),
+            )
+            book_ids.append(int(cur.lastrowid))
+        conn.commit()
+        return book_ids
+    finally:
+        conn.close()
+
+
+def _slug_by_book_id(db_path: Path) -> dict[int, str]:
+    """Return a ``{book.id: book.slug}`` mapping read directly from SQLite.
+
+    Args:
+        db_path (pathlib.Path): SQLite file already upgraded to ``REVISION``.
+
+    Returns:
+        dict[int, str]: All rows in ``book`` keyed by primary key.
+
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        return {int(row[0]): row[1] for row in conn.execute("SELECT id, slug FROM book")}
+    finally:
+        conn.close()
+
+
+@pytest.mark.migrations
+class TestUpgradeToAddSlugRevision:
+    """``alembic upgrade 92552180df13`` adds and backfills ``book.slug``."""
+
+    def test_records_revision_in_alembic_version(
+        self,
+        alembic_config: Config,
+        sqlite_db_path: Path,
+    ) -> None:
+        """Persist ``92552180df13`` in ``alembic_version`` once applied.
+
+        Args:
+            alembic_config (Config): Alembic config bound to the test database.
+            sqlite_db_path (pathlib.Path): SQLite file post-upgrade.
+
+        Returns:
+            None
+
+        """
+        command.upgrade(alembic_config, REVISION)
+
+        assert alembic_version(sqlite_db_path) == [REVISION]
+
+    def test_book_has_slug_column(
+        self,
+        alembic_config: Config,
+        sqlite_db_path: Path,
+    ) -> None:
+        """Add ``slug`` to ``book``.
+
+        Args:
+            alembic_config (Config): Alembic config bound to the test database.
+            sqlite_db_path (pathlib.Path): SQLite file post-upgrade.
+
+        Returns:
+            None
+
+        """
+        command.upgrade(alembic_config, REVISION)
+
+        columns = {row[1] for row in _book_table_info(sqlite_db_path)}
+        assert NEW_COLUMN in columns
+
+    def test_slug_is_not_null(
+        self,
+        alembic_config: Config,
+        sqlite_db_path: Path,
+    ) -> None:
+        """Declare ``slug`` as NOT NULL after the backfill completes.
+
+        Args:
+            alembic_config (Config): Alembic config bound to the test database.
+            sqlite_db_path (pathlib.Path): SQLite file post-upgrade.
+
+        Returns:
+            None
+
+        """
+        command.upgrade(alembic_config, REVISION)
+
+        row = next(
+            (r for r in _book_table_info(sqlite_db_path) if r[1] == NEW_COLUMN),
+            None,
+        )
+        assert row is not None, f"{NEW_COLUMN} column missing from book"
+        assert bool(row[3]) is True, f"{NEW_COLUMN} should be NOT NULL"
+
+    def test_slug_has_unique_constraint(
+        self,
+        alembic_config: Config,
+        sqlite_db_path: Path,
+    ) -> None:
+        """Enforce single-column uniqueness on ``slug``.
+
+        Args:
+            alembic_config (Config): Alembic config bound to the test database.
+            sqlite_db_path (pathlib.Path): SQLite file post-upgrade.
+
+        Returns:
+            None
+
+        """
+        command.upgrade(alembic_config, REVISION)
+
+        uniques = _unique_columns(sqlite_db_path, "book")
+        assert NEW_UNIQUE_CONSTRAINT_TARGETS.issubset(uniques)
+
+    def test_slug_has_index(
+        self,
+        alembic_config: Config,
+        sqlite_db_path: Path,
+    ) -> None:
+        """Create the ``idx_book_slug`` index.
+
+        Args:
+            alembic_config (Config): Alembic config bound to the test database.
+            sqlite_db_path (pathlib.Path): SQLite file post-upgrade.
+
+        Returns:
+            None
+
+        """
+        command.upgrade(alembic_config, REVISION)
+
+        assert NEW_INDEX in _index_names(sqlite_db_path, "book")
+
+    def test_preserves_pre_existing_book_columns(
+        self,
+        alembic_config: Config,
+        sqlite_db_path: Path,
+    ) -> None:
+        """Leave the rest of ``book``'s column set untouched.
+
+        Args:
+            alembic_config (Config): Alembic config bound to the test database.
+            sqlite_db_path (pathlib.Path): SQLite file post-upgrade.
+
+        Returns:
+            None
+
+        """
+        command.upgrade(alembic_config, REVISION)
+
+        columns = {row[1] for row in _book_table_info(sqlite_db_path)}
+        missing = PRE_EXISTING_BOOK_COLUMNS - columns
+        assert not missing, f"Missing pre-existing columns on book: {missing}"
+
+    def test_preserves_pre_existing_tables(
+        self,
+        alembic_config: Config,
+        sqlite_db_path: Path,
+    ) -> None:
+        """Leave the prior-revision table set in place.
+
+        Args:
+            alembic_config (Config): Alembic config bound to the test database.
+            sqlite_db_path (pathlib.Path): SQLite file post-upgrade.
+
+        Returns:
+            None
+
+        """
+        command.upgrade(alembic_config, REVISION)
+
+        assert PRE_EXISTING_TABLES.issubset(table_names(sqlite_db_path))
+
+    def test_restores_book_author_foreign_key(
+        self,
+        alembic_config: Config,
+        sqlite_db_path: Path,
+    ) -> None:
+        """Re-create ``book.fk_author_id`` after the batch alteration.
+
+        The migration must drop the FK before SQLite can rebuild ``book`` in
+        batch mode; the upgrade is only sound if the FK comes back.
+
+        Args:
+            alembic_config (Config): Alembic config bound to the test database.
+            sqlite_db_path (pathlib.Path): SQLite file post-upgrade.
+
+        Returns:
+            None
+
+        """
+        command.upgrade(alembic_config, REVISION)
+
+        assert ("author", "author_id", "id") in _foreign_key_targets(sqlite_db_path, "book")
+
+    def test_restores_page_book_foreign_key(
+        self,
+        alembic_config: Config,
+        sqlite_db_path: Path,
+    ) -> None:
+        """Re-create ``page.fk_book_id`` after the batch alteration.
+
+        ``page.fk_book_id`` is dropped so SQLite can rebuild ``book``; the
+        migration must put it back.
+
+        Args:
+            alembic_config (Config): Alembic config bound to the test database.
+            sqlite_db_path (pathlib.Path): SQLite file post-upgrade.
+
+        Returns:
+            None
+
+        """
+        command.upgrade(alembic_config, REVISION)
+
+        assert ("book", "book_id", "id") in _foreign_key_targets(sqlite_db_path, "page")
+
+    def test_backfill_slugifies_existing_book_names(
+        self,
+        alembic_config: Config,
+        sqlite_db_path: Path,
+    ) -> None:
+        """Slugify each existing ``book.name`` into ``slug`` on upgrade.
+
+        Args:
+            alembic_config (Config): Alembic config bound to the test database.
+            sqlite_db_path (pathlib.Path): SQLite file post-upgrade.
+
+        Returns:
+            None
+
+        """
+        command.upgrade(alembic_config, PREVIOUS_REVISION)
+        [book_id] = _seed_books(sqlite_db_path, ["Hello, World!"])
+
+        command.upgrade(alembic_config, REVISION)
+
+        assert _slug_by_book_id(sqlite_db_path)[book_id] == "hello-world"
+
+    def test_backfill_resolves_collisions_with_numeric_suffix(
+        self,
+        alembic_config: Config,
+        sqlite_db_path: Path,
+    ) -> None:
+        """Distinct names that slugify to the same base get ``-1``, ``-2``... suffixes.
+
+        Args:
+            alembic_config (Config): Alembic config bound to the test database.
+            sqlite_db_path (pathlib.Path): SQLite file post-upgrade.
+
+        Returns:
+            None
+
+        """
+        command.upgrade(alembic_config, PREVIOUS_REVISION)
+        book_ids = _seed_books(
+            sqlite_db_path,
+            ["Hello, World!", "Hello! World", "hello world"],
+        )
+
+        command.upgrade(alembic_config, REVISION)
+
+        slugs = _slug_by_book_id(sqlite_db_path)
+        assigned = {slugs[book_id] for book_id in book_ids}
+        assert assigned == {"hello-world", "hello-world-1", "hello-world-2"}
+
+    def test_backfill_falls_back_to_book_id_for_empty_slug(
+        self,
+        alembic_config: Config,
+        sqlite_db_path: Path,
+    ) -> None:
+        """Names whose slug is empty fall back to ``book-<id>``.
+
+        Punctuation-only names like ``"!!!"`` slugify to the empty string;
+        the migration's fallback gives them a deterministic, unique slug.
+
+        Args:
+            alembic_config (Config): Alembic config bound to the test database.
+            sqlite_db_path (pathlib.Path): SQLite file post-upgrade.
+
+        Returns:
+            None
+
+        """
+        command.upgrade(alembic_config, PREVIOUS_REVISION)
+        [book_id] = _seed_books(sqlite_db_path, ["!!!"])
+
+        command.upgrade(alembic_config, REVISION)
+
+        assert _slug_by_book_id(sqlite_db_path)[book_id] == f"book-{book_id}"
+
+
+@pytest.mark.migrations
+class TestDowngradeFromAddSlugRevision:
+    """Downgrading from ``92552180df13`` only removes ``book.slug``."""
+
+    def test_downgrade_removes_slug_column(
+        self,
+        alembic_config: Config,
+        sqlite_db_path: Path,
+    ) -> None:
+        """Drop ``slug`` when stepping back one revision.
+
+        Args:
+            alembic_config (Config): Alembic config bound to the test database.
+            sqlite_db_path (pathlib.Path): SQLite file post-downgrade.
+
+        Returns:
+            None
+
+        """
+        command.upgrade(alembic_config, REVISION)
+        command.downgrade(alembic_config, PREVIOUS_REVISION)
+
+        columns = {row[1] for row in _book_table_info(sqlite_db_path)}
+        assert NEW_COLUMN not in columns
+
+    def test_downgrade_removes_slug_index(
+        self,
+        alembic_config: Config,
+        sqlite_db_path: Path,
+    ) -> None:
+        """Drop ``idx_book_slug`` on downgrade.
+
+        Args:
+            alembic_config (Config): Alembic config bound to the test database.
+            sqlite_db_path (pathlib.Path): SQLite file post-downgrade.
+
+        Returns:
+            None
+
+        """
+        command.upgrade(alembic_config, REVISION)
+        command.downgrade(alembic_config, PREVIOUS_REVISION)
+
+        assert NEW_INDEX not in _index_names(sqlite_db_path, "book")
+
+    def test_downgrade_preserves_pre_existing_book_columns(
+        self,
+        alembic_config: Config,
+        sqlite_db_path: Path,
+    ) -> None:
+        """Leave the other ``book`` columns intact after downgrade.
+
+        Args:
+            alembic_config (Config): Alembic config bound to the test database.
+            sqlite_db_path (pathlib.Path): SQLite file post-downgrade.
+
+        Returns:
+            None
+
+        """
+        command.upgrade(alembic_config, REVISION)
+        command.downgrade(alembic_config, PREVIOUS_REVISION)
+
+        columns = {row[1] for row in _book_table_info(sqlite_db_path)}
+        missing = PRE_EXISTING_BOOK_COLUMNS - columns
+        assert not missing, f"Pre-existing columns lost on downgrade: {missing}"
+
+    def test_downgrade_preserves_pre_existing_tables(
+        self,
+        alembic_config: Config,
+        sqlite_db_path: Path,
+    ) -> None:
+        """Leave every prior-revision table in place after downgrade.
+
+        Args:
+            alembic_config (Config): Alembic config bound to the test database.
+            sqlite_db_path (pathlib.Path): SQLite file post-downgrade.
+
+        Returns:
+            None
+
+        """
+        command.upgrade(alembic_config, REVISION)
+        command.downgrade(alembic_config, PREVIOUS_REVISION)
+
+        assert PRE_EXISTING_TABLES.issubset(table_names(sqlite_db_path))
+
+    def test_downgrade_restores_book_author_foreign_key(
+        self,
+        alembic_config: Config,
+        sqlite_db_path: Path,
+    ) -> None:
+        """Re-create ``book.fk_author_id`` after the downgrade batch alteration.
+
+        Args:
+            alembic_config (Config): Alembic config bound to the test database.
+            sqlite_db_path (pathlib.Path): SQLite file post-downgrade.
+
+        Returns:
+            None
+
+        """
+        command.upgrade(alembic_config, REVISION)
+        command.downgrade(alembic_config, PREVIOUS_REVISION)
+
+        assert ("author", "author_id", "id") in _foreign_key_targets(sqlite_db_path, "book")
+
+    def test_downgrade_restores_page_book_foreign_key(
+        self,
+        alembic_config: Config,
+        sqlite_db_path: Path,
+    ) -> None:
+        """Re-create ``page.fk_book_id`` after the downgrade batch alteration.
+
+        Args:
+            alembic_config (Config): Alembic config bound to the test database.
+            sqlite_db_path (pathlib.Path): SQLite file post-downgrade.
+
+        Returns:
+            None
+
+        """
+        command.upgrade(alembic_config, REVISION)
+        command.downgrade(alembic_config, PREVIOUS_REVISION)
+
+        assert ("book", "book_id", "id") in _foreign_key_targets(sqlite_db_path, "page")
+
+    def test_downgrade_resets_alembic_version_to_previous(
+        self,
+        alembic_config: Config,
+        sqlite_db_path: Path,
+    ) -> None:
+        """Update ``alembic_version`` to the predecessor revision.
+
+        Args:
+            alembic_config (Config): Alembic config bound to the test database.
+            sqlite_db_path (pathlib.Path): SQLite file post-downgrade.
+
+        Returns:
+            None
+
+        """
+        command.upgrade(alembic_config, REVISION)
+        command.downgrade(alembic_config, PREVIOUS_REVISION)
+
+        assert alembic_version(sqlite_db_path) == [PREVIOUS_REVISION]

--- a/backend/tests/migrations/test_add_watches_count_to_book_revision.py
+++ b/backend/tests/migrations/test_add_watches_count_to_book_revision.py
@@ -117,9 +117,7 @@ class TestUpgradeToAddWatchesCountRevision:
             None,
         )
         assert row is not None, f"{NEW_COLUMN} column missing from book"
-        assert row[2].upper() == "INTEGER", (
-            f"{NEW_COLUMN} type expected INTEGER, got {row[2]}"
-        )
+        assert row[2].upper() == "INTEGER", f"{NEW_COLUMN} type expected INTEGER, got {row[2]}"
         assert bool(row[3]) is True, f"{NEW_COLUMN} should be NOT NULL"
 
     def test_preserves_pre_existing_book_columns(

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1165,6 +1165,23 @@ wheels = [
 ]
 
 [[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
+]
+
+[package.optional-dependencies]
+unidecode = [
+    { name = "unidecode" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1260,6 +1277,7 @@ dependencies = [
     { name = "pydantic-settings", extra = ["yaml"] },
     { name = "pydash" },
     { name = "pyjwt" },
+    { name = "python-slugify", extra = ["unidecode"] },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn" },
 ]
@@ -1291,6 +1309,7 @@ requires-dist = [
     { name = "pydantic-settings", extras = ["yaml"], specifier = ">=2.14.1" },
     { name = "pydash", specifier = ">=8.0" },
     { name = "pyjwt", specifier = ">=2.12.1" },
+    { name = "python-slugify", extras = ["unidecode"], specifier = ">=8.0.4" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.44" },
     { name = "uvicorn", specifier = ">=0.47.0" },
 ]
@@ -1412,6 +1431,15 @@ wheels = [
 ]
 
 [[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
+
+[[package]]
 name = "tornado"
 version = "6.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1465,6 +1493,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "unidecode"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/7d/a8a765761bbc0c836e397a2e48d498305a865b70a8600fd7a942e85dcf63/Unidecode-1.4.0.tar.gz", hash = "sha256:ce35985008338b676573023acc382d62c264f307c8f7963733405add37ea2b23", size = 200149, upload-time = "2025-04-24T08:45:03.798Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/b7/559f59d57d18b44c6d1250d2eeaa676e028b9c527431f5d0736478a73ba1/Unidecode-1.4.0-py3-none-any.whl", hash = "sha256:c3c7606c27503ad8d501270406e345ddb480a7b5f38827eafe4fa82a137f0021", size = 235837, upload-time = "2025-04-24T08:45:01.609Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces a new unique, non-null `slug` field to the `book` model, ensures slug values are generated and enforced at both the database and application levels, and updates related API models and migrations accordingly. It also strengthens validation for various request models and adds new dependencies to support these changes.

**Database and Model Enhancements:**

* Added a unique, indexed, and non-null `slug` column to the `book` table, with a migration to backfill existing books by slugifying their names and handling collisions. The migration also updates foreign key constraints as needed for SQLite compatibility. (`backend/src/reader/services/alembic/migrations/versions/2026-05-19_12-26_92552180df13_add_slug_field.py`, `backend/src/reader/services/database/models/book.py`, `backend/pyproject.toml`) [[1]](diffhunk://#diff-ad75a8040d1e398d0c5cea56bbe6c9d6dba10707f623be88edac6fe0f883a57aR1-R93) [[2]](diffhunk://#diff-c410c6996b67862c2372cf095efe4685297fabab28cc635a9e19e8df1d3934f1R37-R54) [[3]](diffhunk://#diff-9f2cf60079756e94b31dbaeb145297215236d3c0135647163c2e51b80fd81551R34)
* The `Book` SQLAlchemy model now generates a slug from the book name if one is not provided, ensuring consistency for new entries. (`backend/src/reader/services/database/models/book.py`)

**API and Validation Improvements:**

* API response and query models for books now include the new `slug` field, and support filtering/sorting by slug and watches count. (`backend/src/reader/modules/routers/models/responses/books/get_single_book_response.py`, `backend/src/reader/modules/routers/models/responses/books/simple_book_response.py`, `backend/src/reader/modules/routers/models/requests/books/get_all_books_query.py`) [[1]](diffhunk://#diff-64804073db99a36bfd0c816720452918bd8f31141a63f19e4cf904bd0d764812R21) [[2]](diffhunk://#diff-05453787cfc63799844df93467cdf0116f47a1c88accd83b4d447515685d36b2R19) [[3]](diffhunk://#diff-226f922d9d7e4418f4a2d5696a6f78995e1912c51077add1eb663008e8a1cbfdL12-R13)
* Request models for creating and patching authors, books, categories, and pages now enforce stricter validation, including minimum and maximum string lengths and required positive integers where appropriate. (`backend/src/reader/modules/routers/models/requests/authors/post_author_body.py`, `backend/src/reader/modules/routers/models/requests/authors/patch_author_body.py`, `backend/src/reader/modules/routers/models/requests/books/post_book_body.py`, `backend/src/reader/modules/routers/models/requests/books/patch_book_body.py`, `backend/src/reader/modules/routers/models/requests/categories/post_category_body.py`, `backend/src/reader/modules/routers/models/requests/categories/patch_category_body.py`, `backend/src/reader/modules/routers/models/requests/pages/post_page_body.py`, `backend/src/reader/modules/routers/models/requests/pages/patch_page_body.py`) [[1]](diffhunk://#diff-09c693224ed5343441d859c47a74226f9e4a6d9361f3bde34eb63e3d7bdf13a2L13-R14) [[2]](diffhunk://#diff-e1bed6c79135e33e8b7ee023d4f6debc1b0f40d95f8a1ad38667ea1dc1158e8aL13-R14) [[3]](diffhunk://#diff-6ea51649034e5864790f8d1b5ad67c7f2a631ee1e30f02ca90bfab43360bcedcL13-R14) [[4]](diffhunk://#diff-c99f0c552a552317554d74a7fbaa58b00827adc6f6d8added8e62c0a7e3826d3L13-R14) [[5]](diffhunk://#diff-22685678953e56ce0b77b3f0d455b1617e215dbe0bfa9b371b90f068b3047db4L13-R14) [[6]](diffhunk://#diff-4286854433dbd92443b2ae9f397a43007b58b494eb5ff367e6cf3a39ad5a3d59L13-R14) [[7]](diffhunk://#diff-11065c8b8fa670a683121913461de8163e1aa237579886190d6cff3c16d6ed35L13-R13) [[8]](diffhunk://#diff-b0cb0786a4e070ded74a32cdada8d633a6d058000aae508f07b172814dbffe96L13-R13)

**Migrations and Constraints:**

* Updated the initial migration to add a unique constraint on author names and to move the unique book name constraint to a new unique constraint, aligning with the new slug uniqueness enforcement. (`backend/src/reader/services/alembic/migrations/versions/2025_01_18_1324-8e3f5d72efaf_init.py`)

**Dependency and Version Updates:**

* Added `python-slugify` as a dependency to support slug generation, and bumped the backend version to `0.1.8`. (`backend/pyproject.toml`, `backend/src/reader/__init__.py`) [[1]](diffhunk://#diff-9f2cf60079756e94b31dbaeb145297215236d3c0135647163c2e51b80fd81551R34) [[2]](diffhunk://#diff-b6d5f288cbf120cb7c66a8a448a100471c744c293f186853450d81e8c522801fL5-R5)

**Testing and Code Quality:**

* Minor test and formatting improvements for clarity and consistency in test files. (`backend/tests/api/test_books_api.py`, `backend/tests/migrations/test_add_create_at_update_at_columns_revision.py`, `backend/tests/migrations/test_add_watches_count_to_book_revision.py`) [[1]](diffhunk://#diff-3a7fd258414596ddf729ce851ab6a92b80b6448f5c305d74cbb65cc3386600d8L262-R262) [[2]](diffhunk://#diff-2b796d898f291aecf385d897a0c6517b9dce02cd6597cb1084fae9b1add3a5b2L120-R120) [[3]](diffhunk://#diff-4b96c91f8d5f5e044e8a2b28824d19feca042465076c2cc495d0b65054c2821eL120-R120)