### PR TITLE
feat: Enable slug

### DIFF
--- a/backend/src/reader/__init__.py
+++ b/backend/src/reader/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ("__version__",)
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"

--- a/backend/src/reader/modules/routers/api/v1/books.py
+++ b/backend/src/reader/modules/routers/api/v1/books.py
@@ -67,14 +67,13 @@ async def get_all_books(
     dependencies=[Depends(user_authorized)],
 )
 async def get_single_book(
-    book_id: Annotated[int | str, Path(..., description="The ID or slug of the book")],
+    book_id: Annotated[int, Path(..., description="The ID of the book")],
     db: Annotated[AsyncDatabaseClient, Depends(get_db)],
 ) -> GetSingleBookResponse:
     """Return one book by primary key.
 
     Args:
-        book_id (int | str): Identifier of the book to load.
-            If the ID is a string, it is treated as a slug.
+        book_id (int): Identifier of the book to load.
         db (AsyncDatabaseClient): Database session from dependency injection.
 
     Returns:
@@ -88,9 +87,7 @@ async def get_single_book(
     books_dao = BookDAO(database_client=db)
 
     try:
-        payload = (
-            await books_dao.get_by_pk(book_id) if isinstance(book_id, int) else await books_dao.get_by_slug(book_id)
-        )
+        payload = await books_dao.get_by_pk(book_id)
     except NoResultFound as e:
         logger.error(f"Book with ID {book_id} not found")
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Book not found") from e
@@ -98,6 +95,46 @@ async def get_single_book(
         logger.exception("Error getting single book", exc_info=e)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Error getting single book"
+        ) from e
+
+    return GetSingleBookResponse.model_validate(payload)
+
+
+@router.get(
+    "/slug/{slug}",
+    response_model=GetSingleBookResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get a single book by slug",
+    dependencies=[Depends(user_authorized)],
+)
+async def get_single_book_by_slug(
+    slug: Annotated[str, Path(..., description="The slug of the book")],
+    db: Annotated[AsyncDatabaseClient, Depends(get_db)],
+) -> GetSingleBookResponse:
+    """Return one book by slug.
+
+    Args:
+        slug (str): URL slug of the book to load.
+        db (AsyncDatabaseClient): Database session from dependency injection.
+
+    Returns:
+        GetSingleBookResponse: Serialized book.
+
+    Raises:
+        HTTPException: If the book does not exist (404) or loading fails (500).
+
+    """
+    books_dao = BookDAO(database_client=db)
+
+    try:
+        payload = await books_dao.get_by_slug(slug)
+    except NoResultFound as e:
+        logger.error(f"Book with slug {slug} not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Book not found") from e
+    except SQLAlchemyError as e:
+        logger.exception("Error getting single book by slug", exc_info=e)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Error getting single book by slug"
         ) from e
 
     return GetSingleBookResponse.model_validate(payload)

--- a/backend/src/reader/modules/routers/api/v1/books.py
+++ b/backend/src/reader/modules/routers/api/v1/books.py
@@ -67,13 +67,14 @@ async def get_all_books(
     dependencies=[Depends(user_authorized)],
 )
 async def get_single_book(
-    book_id: Annotated[int, Path(..., description="The ID of the book")],
+    book_id: Annotated[int | str, Path(..., description="The ID or slug of the book")],
     db: Annotated[AsyncDatabaseClient, Depends(get_db)],
 ) -> GetSingleBookResponse:
     """Return one book by primary key.
 
     Args:
-        book_id (int): Identifier of the book to load.
+        book_id (int | str): Identifier of the book to load.
+            If the ID is a string, it is treated as a slug.
         db (AsyncDatabaseClient): Database session from dependency injection.
 
     Returns:
@@ -87,7 +88,9 @@ async def get_single_book(
     books_dao = BookDAO(database_client=db)
 
     try:
-        payload = await books_dao.get_by_pk(book_id)
+        payload = (
+            await books_dao.get_by_pk(book_id) if isinstance(book_id, int) else await books_dao.get_by_slug(book_id)
+        )
     except NoResultFound as e:
         logger.error(f"Book with ID {book_id} not found")
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Book not found") from e

--- a/backend/src/reader/services/daos/book_dao.py
+++ b/backend/src/reader/services/daos/book_dao.py
@@ -31,6 +31,21 @@ class BookDAO(BaseDAO[Book]):
     select_in_options_single = (Book.author, Book.categories, Book.pages)
     select_in_options_all = (Book.author,)
 
+    async def get_by_slug(self, slug: str) -> Book:
+        """Return the book whose ``slug`` field matches ``slug``.
+
+        Uses the same session handling and eager loads as :meth:`get_by_pk`,
+        keyed on ``Book.slug`` rather than the default primary-key attribute.
+
+        Args:
+            slug (str): Slug value to resolve.
+
+        Returns:
+            Book: Matching ORM instance.
+
+        """
+        return await self.get_by_pk(slug, "slug")
+
     async def _increment_watches_count_raw(self, session: AsyncSession, book_id: int) -> None:
         """Increment ``watches_count`` by one for the row matching ``book_id``.
 

--- a/backend/tests/api/test_books_api.py
+++ b/backend/tests/api/test_books_api.py
@@ -108,6 +108,45 @@ class TestBooksApi:
         assert response.status_code == 404
         assert response.json()["detail"] == "Book not found"
 
+    async def test_get_single_book_by_slug_returns_persisted_row(self, admin_client: AsyncClient) -> None:
+        """GET by slug returns the row previously created via POST.
+
+        Args:
+            admin_client (AsyncClient): Admin-authenticated HTTP client.
+
+        Returns:
+            None
+
+        """
+        author_id = await _create_author(admin_client, first_name="Arthur")
+        created = (
+            await admin_client.post("/api/v1/book", json={"name": "Hyperion Cantos", "author_id": author_id})
+        ).json()
+
+        response = await admin_client.get(f"/api/v1/book/slug/{created['slug']}")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["id"] == created["id"]
+        assert body["name"] == "Hyperion Cantos"
+        assert body["slug"] == created["slug"]
+        assert body["authorId"] == author_id
+
+    async def test_get_single_book_by_slug_missing_returns_404(self, admin_client: AsyncClient) -> None:
+        """Unknown slugs surface as 404 Not Found.
+
+        Args:
+            admin_client (AsyncClient): Admin-authenticated HTTP client.
+
+        Returns:
+            None
+
+        """
+        response = await admin_client.get("/api/v1/book/slug/does-not-exist")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Book not found"
+
     async def test_get_all_books_paginates_and_reports_total(self, admin_client: AsyncClient) -> None:
         """GET list returns rows plus matching pagination metadata.
 


### PR DESCRIPTION
This pull request introduces support for fetching a book by either its numeric ID or its slug in the API. It updates the endpoint logic to handle both types of identifiers and adds a new method to the data access layer for querying by slug. The version number is also incremented to reflect these changes.

API improvements:

* The `get_single_book` endpoint now accepts either an integer ID or a string slug as the `book_id` parameter, allowing clients to fetch a book by its slug as well as its numeric ID.
* The endpoint logic is updated to call either `get_by_pk` or the new `get_by_slug` method based on the type of `book_id`.

Data access enhancements:

* A new `get_by_slug` method is added to the `BookDAO` class, enabling efficient lookup of books by their slug field.

Versioning:

* The package version is incremented from `0.1.8` to `0.1.9` to reflect the new functionality.