### PR TITLE
fix: Update add book command

### DIFF
--- a/backend/src/reader/__init__.py
+++ b/backend/src/reader/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ("__version__",)
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"

--- a/backend/src/reader/commands/add_book/add_book_command.py
+++ b/backend/src/reader/commands/add_book/add_book_command.py
@@ -27,13 +27,15 @@ class AddBookCommand(BaseCommand):
     book_name: str | None = None
     file_extensions: tuple[str, ...] = (".jpg", ".jpeg", ".png")
 
-    def __init__(self, book_path: Path | str, app_config: AppConfig | None = None):
+    def __init__(self, book_path: Path | str, app_config: AppConfig | None = None, static_url: str = "/static/images"):
         """Create an import command for the given book folder.
 
         Args:
             book_path (Path | str): Directory containing page images (.jpg/.jpeg/.png).
             app_config (AppConfig, optional): Database and app configuration.
                 Defaults to ``AppConfig.get_or_create()`` when omitted.
+            static_url (str, optional): The URL prefix for static files.
+                Defaults to ``/static/images``.
 
         Returns:
             None
@@ -41,6 +43,7 @@ class AddBookCommand(BaseCommand):
         """
         self.book_path = Path(book_path)
         self.app_config = app_config or AppConfig.get_or_create()
+        self.static_url = static_url
 
     def _book_structure(
         self, book_cover: str | None = None, pages: list[str] | None = None
@@ -144,7 +147,7 @@ class AddBookCommand(BaseCommand):
     async def execute(self):
         """Create author, book, and page rows and print a JSON summary to stdout.
 
-        Page paths are stored as ``/static/i/{grandparent}/{parent}/{filename}`` relative-style
+        Page paths are stored as ``{self.static_url}/{grandparent}/{parent}/{filename}`` relative-style
         strings derived from the image files in ``book_path``.
 
         Returns:
@@ -157,7 +160,7 @@ class AddBookCommand(BaseCommand):
 
         for item in self.book_path.iterdir():
             if item.is_file() and item.suffix in self.file_extensions:
-                pages.append(f"/static/i/{item.parent.parent.name}/{item.parent.name}/{item.name}")
+                pages.append(f"{self.static_url}/{item.parent.parent.name}/{item.parent.name}/{item.name}")
 
         pages.sort()
 

--- a/backend/src/reader/commands/add_book/add_book_command.py
+++ b/backend/src/reader/commands/add_book/add_book_command.py
@@ -43,7 +43,7 @@ class AddBookCommand(BaseCommand):
         """
         self.book_path = Path(book_path)
         self.app_config = app_config or AppConfig.get_or_create()
-        self.static_url = static_url
+        self.static_url = static_url.strip().rstrip("/")
 
     def _book_structure(
         self, book_cover: str | None = None, pages: list[str] | None = None
@@ -147,8 +147,8 @@ class AddBookCommand(BaseCommand):
     async def execute(self):
         """Create author, book, and page rows and print a JSON summary to stdout.
 
-        Page paths are stored as ``{self.static_url}/{grandparent}/{parent}/{filename}`` relative-style
-        strings derived from the image files in ``book_path``.
+        Page paths are stored as ``{static_url}/{grandparent}/{parent}/{filename}`` relative-style
+            strings derived from the image files in ``book_path``.
 
         Returns:
             None

--- a/backend/src/reader/utils/cli/main.py
+++ b/backend/src/reader/utils/cli/main.py
@@ -74,8 +74,9 @@ def run(host: str, port: int, reload: bool) -> None:
 @main.command(help="Add a book to the Reader application.")
 @click.option("--book-path", type=click.Path(exists=True, file_okay=False, dir_okay=True), required=True)
 @click.option("--preview", is_flag=True, help="Preview the book structure.", default=False)
+@click.option("--static-url", type=str, help="The URL prefix for static files.", default="/static/images")
 @click.pass_context
-async def add_book(ctx: click.Context, book_path: str, preview: bool) -> None:
+async def add_book(ctx: click.Context, book_path: str, preview: bool, static_url: str) -> None:
     """Add a book from a local directory or print a dry-run preview.
 
     Initializes and validates the add-book workflow against ``book_path``. When
@@ -86,13 +87,15 @@ async def add_book(ctx: click.Context, book_path: str, preview: bool) -> None:
         book_path (str): Path to the book directory on disk.
         preview (bool, optional): If true, print the command only. Defaults to
             ``False``.
+        static_url (str, optional): The URL prefix for static files.
+            Defaults to ``/static/images``.
 
     Returns:
         None
 
     """
     app_config: AppConfig = ctx.obj["config"]
-    command = AddBookCommand(book_path, app_config=app_config)
+    command = AddBookCommand(book_path, app_config=app_config, static_url=static_url)
     await command.initialize()
     await command.validate()
 


### PR DESCRIPTION
This pull request introduces a configurable static files URL prefix for the "add book" workflow, allowing users to specify the URL path used for image resources instead of relying on a hardcoded value. It updates both the command-line interface and the underlying command logic to support this new option. Additionally, the package version is incremented to reflect this change.

Enhancements to static file URL handling:

* Added a `static_url` parameter (defaulting to `/static/images`) to the `AddBookCommand` class, allowing the URL prefix for static files to be customized.
* Updated the logic in `AddBookCommand` so that page paths are constructed using the configurable `static_url` rather than a hardcoded path. [[1]](diffhunk://#diff-4e0f7edf256e3f3cfc8a3589e9af4c5c4c75296846952d68c4ed5afd2429b7c2L147-R150) [[2]](diffhunk://#diff-4e0f7edf256e3f3cfc8a3589e9af4c5c4c75296846952d68c4ed5afd2429b7c2L160-R163)

Command-line interface improvements:

* Added a `--static-url` option to the `add_book` CLI command, enabling users to set the static file URL prefix from the command line.
* Passed the `static_url` value from the CLI to the `AddBookCommand` when initializing the command.

Version update:

* Bumped the package version from `0.1.9` to `0.1.10` in `__init__.py`.