### PR TITLE
feat: Update branch references from master to main in workflow files

### DIFF
--- a/.github/workflows/build_backend.yml
+++ b/.github/workflows/build_backend.yml
@@ -3,11 +3,11 @@ name: build-backend
 on:
   push:
     branches:
-      - master
+      - main
       - development
   pull_request:
     branches:
-      - master
+      - main
       - development
 
 jobs:

--- a/.github/workflows/build_frontend.yml
+++ b/.github/workflows/build_frontend.yml
@@ -3,11 +3,11 @@ name: build-frontend
 on:
   push:
     branches:
-      - master
+      - main
       - development
   pull_request:
     branches:
-      - master
+      - main
       - development
 
 jobs:

--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -3,11 +3,11 @@ name: test-backend
 on:
   push:
     branches:
-      - master
+      - main
       - development
   pull_request:
     branches:
-      - master
+      - main
       - development
 
 jobs:


### PR DESCRIPTION
- Modified the GitHub Actions workflow files for backend and frontend to replace references to the master branch with main, aligning with the updated branch naming convention.
- Ensured that both push and pull request triggers now correctly point to the main branch, maintaining CI/CD functionality.