### PR TITLE
fix: Fix paginating books page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frontend",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frontend",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/books/BooksPage.tsx
+++ b/frontend/src/pages/books/BooksPage.tsx
@@ -27,12 +27,11 @@ export function BooksPage() {
 
   const [books, setBooks] = useState<BookType[] | null>(null);
   const [totalBooks, setTotalBooks] = useState<number>(limit);
-  const [page, setPage] = useState<number>(parseIntWithCheck(searchParams.get('page')));
 
   const { getBooks } = useBookAPIClient();
 
   useEffect(() => {
-    const currentPage = parseIntWithCheck(searchParams.get('page'), { defaultValue: page });
+    const currentPage = parseIntWithCheck(searchParams.get('page'), { defaultValue: 1, min: 1 });
 
     if (!searchParams.get('page')) {
       setSearchParams((prev) => {
@@ -45,11 +44,10 @@ export function BooksPage() {
       const filters = searchParams.get('filters')
         ? JSON.parse(searchParams.get('filters') as string)
         : undefined;
-      getBooks(limit, currentPage * limit, 'created_at', 'desc', filters).then(
+      getBooks(limit, (currentPage - 1) * limit, 'created_at', 'desc', filters).then(
         ({ data, metadata }) => {
           setBooks(data);
           setTotalBooks(metadata.total);
-          setPage(Math.floor(metadata.offset / limit));
         }
       );
     }
@@ -63,7 +61,7 @@ export function BooksPage() {
     <Container>
       <Pagination
         count={Math.ceil(totalBooks / limit)}
-        page={page + 1}
+        page={parseIntWithCheck(searchParams.get('page'), { defaultValue: 1, min: 1 })}
         color="primary"
         shape="circular"
         sx={{ mt: 2 }}


### PR DESCRIPTION
This pull request updates the pagination logic in the `BooksPage` component to fix page offset calculations and ensure the current page is always at least 1. It also bumps the frontend package version to `0.2.2`.

**Pagination logic improvements:**

* Updated the calculation of the books API offset to use `(currentPage - 1) * limit`, ensuring that the correct items are fetched for each page.
* Changed the default value for the page parameter to `1` and enforced a minimum value of `1` when parsing the page from search parameters, preventing invalid or zero page numbers. [[1]](diffhunk://#diff-a92bb981e937bc17dc34c4f5c61760f4257533d4a69acb89c786f99e29c1c437L30-R34) [[2]](diffhunk://#diff-a92bb981e937bc17dc34c4f5c61760f4257533d4a69acb89c786f99e29c1c437L66-R64)

**Project versioning:**

* Bumped the frontend package version from `0.2.1` to `0.2.2` in both `package.json` and `package-lock.json`. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L4-R4) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL3-R9)