### PR TITLE
fix: Update backend cors config

### DIFF
--- a/backend/configurations/local.yaml
+++ b/backend/configurations/local.yaml
@@ -13,6 +13,8 @@ info:
             - GET
             - POST
             - PUT
+            - PATCH
+            - OPTIONS
             - DELETE
         allow_headers:
             - "*"

--- a/backend/configurations/prod.yaml
+++ b/backend/configurations/prod.yaml
@@ -13,6 +13,8 @@ info:
             - GET
             - POST
             - PUT
+            - PATCH
+            - OPTIONS
             - DELETE
         allow_headers:
             - "*"

--- a/backend/src/reader/__init__.py
+++ b/backend/src/reader/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ("__version__",)
 
-__version__ = "0.1.11"
+__version__ = "0.1.12"

--- a/backend/src/reader/commands/add_book/add_book_command.py
+++ b/backend/src/reader/commands/add_book/add_book_command.py
@@ -20,7 +20,7 @@ from .models import AddBookResponse, Author, Book, Page
 class AddBookCommand(BaseCommand[AddBookResponse]):
     """Import books from an author folder on disk into the database."""
 
-    file_extensions: tuple[str, ...] = (".jpg", ".jpeg", ".png")
+    file_extensions: tuple[str, ...] = (".jpg", ".jpeg", ".png", ".webp")
 
     def __init__(
         self, author_path: Path | str, app_config: AppConfig | None = None, static_url: str = "/static/images"

--- a/backend/src/reader/commands/add_book/add_book_command.py
+++ b/backend/src/reader/commands/add_book/add_book_command.py
@@ -92,7 +92,7 @@ class AddBookCommand(BaseCommand[AddBookResponse]):
             count = 0
             for page_path in book_path.iterdir():
                 count += 1
-                if not page_path.is_file() or page_path.suffix not in self.file_extensions:
+                if not page_path.is_file() or page_path.suffix.lower() not in self.file_extensions:
                     raise ValueError(f"Page path {page_path} is not a file or does not have a valid extension")
                 if re.search(r"\d+", page_path.name) is None:
                     raise ValueError(f"Page path {page_path} does not have a valid number in the name")


### PR DESCRIPTION
This pull request adds support for new HTTP methods in CORS configuration and expands the list of supported image file extensions for book imports. The main changes are as follows:

**CORS Configuration Updates:**
* Added support for the `PATCH` and `OPTIONS` HTTP methods to the allowed methods in both `local.yaml` and `prod.yaml` CORS configuration files. This ensures the backend can handle these methods appropriately in different environments. [[1]](diffhunk://#diff-a548bfb31377290da61b3d4e3f7cfc19c498ee4594a02cfc3ca29ef522c5675fR16-R17) [[2]](diffhunk://#diff-cb25bff88cb37ce4b03b236c155635b4363c8843745075c6c298b6040273dd5aR16-R17)

**Book Import Functionality:**
* Updated the `AddBookCommand` in `add_book_command.py` to include `.webp` as a supported image file extension, allowing the import of `.webp` images when adding books.